### PR TITLE
Ensure max image size for uploadcare is limited to 3000

### DIFF
--- a/docs/components/Image.md
+++ b/docs/components/Image.md
@@ -19,7 +19,7 @@ The component can be used for images not hosted with [Uploadcare](https://upload
 | prop name | description | type | required? | default value |
 | --------- | ----------- | ---- | --------- | ------------- |
 | uploadcareDomains | List of custom Uploadcare domains | `Array<String>` | ✗ | [ ] |
-| breakpoints | List of breakpoints used for responsive images | `Array<Integer>` | ✗ | [ 4000, 3000, 2000, 1500, 1000, 800, 600, 400 ] |
+| breakpoints | List of breakpoints used for responsive images | `Array<Integer>` | ✗ | [ 3000, 2000, 1500, 1000, 800, 600, 400 ] |
 | children | Child nodes | `Node` | ✓ | - |
 
 
@@ -83,8 +83,8 @@ export default () => (
 ```html
 <picture>
   <source
-    sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-    srcSet="http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/4000/ 4000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
+    sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+    srcSet="http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
   />
   <img src="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/" alt="Shelley" />
 </picture>
@@ -109,12 +109,12 @@ export default () => (
 ```html
 <picture>
   <source
-    sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-    srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/400/ 400w"
+    sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+    srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/400/ 400w"
   />
   <source
-    sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-    srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/400/ 400w"
+    sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+    srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/400/ 400w"
   />
   <img src="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/" alt="Shelley" />
 </picture>

--- a/src/Image.js
+++ b/src/Image.js
@@ -31,7 +31,7 @@ const UploadCareImage = ({ src, sizeFactor = 1, alt, maintainTransparency, compo
     const imageSrc = `${src}-/format/${type.replace(/^image\//, '')}/`
     return (
       <source
-        srcSet={breakpoints.map(breakpoint => `${imageSrc}-/resize/${breakpoint * sizeFactor}/ ${breakpoint * sizeFactor}w`).join(', ')}
+        srcSet={breakpoints.map(breakpoint => `${imageSrc}-/resize/${Math.min(3000, breakpoint * sizeFactor)}/ ${breakpoint * sizeFactor}w`).join(', ')}
         sizes={breakpoints.map(breakpoint => `(max-width: ${breakpoint}px) ${breakpoint * sizeFactor}px`).concat('100vw').join(', ')}
       />
     )

--- a/src/Image.js
+++ b/src/Image.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 const ImageContext = createContext()
 
-const DEFAULT_BREAKPOINTS = [ 4000, 3000, 2000, 1500, 1000, 800, 600, 400 ]
+const DEFAULT_BREAKPOINTS = [ 3000, 2000, 1500, 1000, 800, 600, 400 ]
 
 export const Provider = ({ children, uploadcareDomains = [], breakpoints = DEFAULT_BREAKPOINTS }) => {
   const getSortedBreakpoints = () => {

--- a/src/__snapshots__/Image.test.js.snap
+++ b/src/__snapshots__/Image.test.js.snap
@@ -10,7 +10,6 @@ exports[`<Image /> it renders correctly with minimal props 1`] = `
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -48,7 +47,6 @@ exports[`<Image /> uploadcare images custom domain images on uploadcare images o
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -69,7 +67,6 @@ exports[`<Image /> uploadcare images custom domain images on uploadcare images o
         alt="An image"
         breakpoints={
           Array [
-            4000,
             3000,
             2000,
             1500,
@@ -88,8 +85,8 @@ exports[`<Image /> uploadcare images custom domain images on uploadcare images o
       >
         <picture>
           <source
-            sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-            srcSet="http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/4000/ 4000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
+            sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+            srcSet="http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, http://uploadcare.example.org/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
           />
           <img
             alt="An image"
@@ -113,7 +110,6 @@ exports[`<Image /> uploadcare images it maintains transparency with maintainTran
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -131,7 +127,6 @@ exports[`<Image /> uploadcare images it maintains transparency with maintainTran
         alt="An image"
         breakpoints={
           Array [
-            4000,
             3000,
             2000,
             1500,
@@ -147,12 +142,12 @@ exports[`<Image /> uploadcare images it maintains transparency with maintainTran
       >
         <picture>
           <source
-            sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/400/ 400w"
+            sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/webp/-/resize/400/ 400w"
           />
           <source
-            sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/400/ 400w"
+            sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/png/-/resize/400/ 400w"
           />
           <img
             alt="An image"
@@ -175,7 +170,6 @@ exports[`<Image /> uploadcare images it renders the uploadcare picture correctly
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -192,7 +186,6 @@ exports[`<Image /> uploadcare images it renders the uploadcare picture correctly
         alt="An image"
         breakpoints={
           Array [
-            4000,
             3000,
             2000,
             1500,
@@ -207,8 +200,8 @@ exports[`<Image /> uploadcare images it renders the uploadcare picture correctly
       >
         <picture>
           <source
-            sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
+            sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
           />
           <img
             alt="An image"
@@ -232,7 +225,6 @@ exports[`<Image /> uploadcare images size factor a higher size factor increases 
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -250,7 +242,6 @@ exports[`<Image /> uploadcare images size factor a higher size factor increases 
         alt="An image"
         breakpoints={
           Array [
-            4000,
             3000,
             2000,
             1500,
@@ -266,8 +257,8 @@ exports[`<Image /> uploadcare images size factor a higher size factor increases 
       >
         <picture>
           <source
-            sizes="(max-width: 4000px) 6000px, (max-width: 3000px) 4500px, (max-width: 2000px) 3000px, (max-width: 1500px) 2250px, (max-width: 1000px) 1500px, (max-width: 800px) 1200px, (max-width: 600px) 900px, (max-width: 400px) 600px, 100vw"
-            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/6000/ 6000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/4500/ 4500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2250/ 2250w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1200/ 1200w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/900/ 900w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w"
+            sizes="(max-width: 3000px) 4500px, (max-width: 2000px) 3000px, (max-width: 1500px) 2250px, (max-width: 1000px) 1500px, (max-width: 800px) 1200px, (max-width: 600px) 900px, (max-width: 400px) 600px, 100vw"
+            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 4500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2250/ 2250w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1200/ 1200w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/900/ 900w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w"
           />
           <img
             alt="An image"
@@ -291,7 +282,6 @@ exports[`<Image /> uploadcare images size factor a lower size factor decreases i
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -309,7 +299,6 @@ exports[`<Image /> uploadcare images size factor a lower size factor decreases i
         alt="An image"
         breakpoints={
           Array [
-            4000,
             3000,
             2000,
             1500,
@@ -325,8 +314,8 @@ exports[`<Image /> uploadcare images size factor a lower size factor decreases i
       >
         <picture>
           <source
-            sizes="(max-width: 4000px) 2000px, (max-width: 3000px) 1500px, (max-width: 2000px) 1000px, (max-width: 1500px) 750px, (max-width: 1000px) 500px, (max-width: 800px) 400px, (max-width: 600px) 300px, (max-width: 400px) 200px, 100vw"
-            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/750/ 750w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/500/ 500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/300/ 300w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/200/ 200w"
+            sizes="(max-width: 3000px) 1500px, (max-width: 2000px) 1000px, (max-width: 1500px) 750px, (max-width: 1000px) 500px, (max-width: 800px) 400px, (max-width: 600px) 300px, (max-width: 400px) 200px, 100vw"
+            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/750/ 750w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/500/ 500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/300/ 300w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/200/ 200w"
           />
           <img
             alt="An image"
@@ -415,7 +404,6 @@ exports[`<Image /> uploadcare images when a custom component is provided the it 
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -438,7 +426,6 @@ exports[`<Image /> uploadcare images when a custom component is provided the it 
         alt="An image"
         breakpoints={
           Array [
-            4000,
             3000,
             2000,
             1500,
@@ -459,8 +446,8 @@ exports[`<Image /> uploadcare images when a custom component is provided the it 
       >
         <picture>
           <source
-            sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
+            sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+            srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
           />
           <CustomComponent
             alt="An image"
@@ -496,7 +483,6 @@ exports[`<Image /> when a custom component is provided the it renders the img wi
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -540,7 +526,6 @@ exports[`<Image /> when no provider exists it still renders the image 1`] = `
     alt="An image"
     breakpoints={
       Array [
-        4000,
         3000,
         2000,
         1500,
@@ -570,7 +555,6 @@ exports[`<Image /> when no provider exists uploadcare images it still renders us
     alt="An image"
     breakpoints={
       Array [
-        4000,
         3000,
         2000,
         1500,
@@ -587,7 +571,6 @@ exports[`<Image /> when no provider exists uploadcare images it still renders us
       alt="An image"
       breakpoints={
         Array [
-          4000,
           3000,
           2000,
           1500,
@@ -602,8 +585,8 @@ exports[`<Image /> when no provider exists uploadcare images it still renders us
     >
       <picture>
         <source
-          sizes="(max-width: 4000px) 4000px, (max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
-          srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/4000/ 4000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
+          sizes="(max-width: 3000px) 3000px, (max-width: 2000px) 2000px, (max-width: 1500px) 1500px, (max-width: 1000px) 1000px, (max-width: 800px) 800px, (max-width: 600px) 600px, (max-width: 400px) 400px, 100vw"
+          srcSet="https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/3000/ 3000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/2000/ 2000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1500/ 1500w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/1000/ 1000w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/800/ 800w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/600/ 600w, https://ucarecdn.com/c19187bc-6028-45fa-bf23-18dd31cd7636/-/format/jpeg/-/resize/400/ 400w"
         />
         <img
           alt="An image"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Commit messages are concise and descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Removed any tech debt where applicable


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* Uploadcare limits image sizes to a maximum of `3000`. This limits the resize value of uploadcare images to `3000`

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: