### PR TITLE
Fix link language prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@input-output-hk/front-end-core-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@input-output-hk/front-end-core-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "IOHK front-end web core React components",
   "main": "components/index.js",
   "scripts": {

--- a/src/Link.js
+++ b/src/Link.js
@@ -22,7 +22,10 @@ Provider.propTypes = {
 const LinkInner = (props) => {
   // Transform original href to prefix language where applicable
   function getHref () {
-    if (props.lang && isRelative(props.href) && !props.isStatic(props.href) && props.href.substring(1, props.lang.length + 1) !== props.lang) return `/${props.lang}${props.href}`
+    if (props.lang && isRelative(props.href) && !props.isStatic(props.href) && !props.href.match(new RegExp(`^/${props.lang}(/?|/.*)$`))) {
+      return `/${props.lang}${props.href}`
+    }
+
     return props.href
   }
 

--- a/src/Link.test.js
+++ b/src/Link.test.js
@@ -34,6 +34,18 @@ describe('<Link />', () => {
       expect(getWrapper({ providerProps: { lang }, props: { href: '/page/' } })).toMatchSnapshot()
     })
 
+    test('/enter/ is still prefixed by the language', () => {
+      expect(getWrapper({ providerProps: { lang }, props: { href: '/enter/' } })).toMatchSnapshot()
+    })
+
+    test('/en is not prefixed by the language', () => {
+      expect(getWrapper({ providerProps: { lang }, props: { href: '/en' } })).toMatchSnapshot()
+    })
+
+    test('/en/ is not prefixed by the language', () => {
+      expect(getWrapper({ providerProps: { lang }, props: { href: '/en/' } })).toMatchSnapshot()
+    })
+
     test('already language prefixed URL\'s are unaffected', () => {
       expect(getWrapper({ providerProps: { lang }, props: { href: '/en/page/' } })).toMatchSnapshot()
     })

--- a/src/__snapshots__/Link.test.js.snap
+++ b/src/__snapshots__/Link.test.js.snap
@@ -55,6 +55,78 @@ exports[`<Link /> when a custom component is used it renders correctly 1`] = `
 </Provider>
 `;
 
+exports[`<Link /> when the context provider has a lang set /en is not prefixed by the language 1`] = `
+<Provider
+  lang="en"
+>
+  <ForwardRef
+    href="/en"
+  >
+    <LinkInner
+      component="a"
+      href="/en"
+      isStatic={[Function]}
+      lang="en"
+    >
+      <a
+        href="/en"
+        lang="en"
+      >
+        A link
+      </a>
+    </LinkInner>
+  </ForwardRef>
+</Provider>
+`;
+
+exports[`<Link /> when the context provider has a lang set /en/ is not prefixed by the language 1`] = `
+<Provider
+  lang="en"
+>
+  <ForwardRef
+    href="/en/"
+  >
+    <LinkInner
+      component="a"
+      href="/en/"
+      isStatic={[Function]}
+      lang="en"
+    >
+      <a
+        href="/en/"
+        lang="en"
+      >
+        A link
+      </a>
+    </LinkInner>
+  </ForwardRef>
+</Provider>
+`;
+
+exports[`<Link /> when the context provider has a lang set /enter/ is still prefixed by the language 1`] = `
+<Provider
+  lang="en"
+>
+  <ForwardRef
+    href="/enter/"
+  >
+    <LinkInner
+      component="a"
+      href="/enter/"
+      isStatic={[Function]}
+      lang="en"
+    >
+      <a
+        href="/en/enter/"
+        lang="en"
+      >
+        A link
+      </a>
+    </LinkInner>
+  </ForwardRef>
+</Provider>
+`;
+
 exports[`<Link /> when the context provider has a lang set absolute URL's are unaffected 1`] = `
 <Provider
   lang="en"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Commit messages are concise and descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Removed any tech debt where applicable


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* Fixed link component rendering with language prefix, previously with a lang of `en` links such as `/enter/` would not be prefixed.

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: